### PR TITLE
change log_group_exists? to look at the group name

### DIFF
--- a/lib/fluent/plugin/out_cloudwatch_logs.rb
+++ b/lib/fluent/plugin/out_cloudwatch_logs.rb
@@ -255,7 +255,7 @@ module Fluent
     def log_group_exists?(group_name)
       if @sequence_tokens[group_name]
         true
-      elsif @logs.describe_log_groups.log_groups.any? {|i| i.log_group_name == group_name }
+      elsif @logs.describe_log_groups({log_group_name_prefix: group_name}).log_groups != []
         @sequence_tokens[group_name] = {}
         true
       else


### PR DESCRIPTION
http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatchLogs/Client.html#describe_log_groups-instance_method
# describe_log_groups will return a max of 50 log groups.  If log_group_exists? is called on group ordered > 50th, it will erroneously return false.  Passing the group name as the prefix ensures the log group will be found if it is present.

This also reduces the HTTP overhead of pulling lots of unimportant log groups when you're only really needing information on one.
